### PR TITLE
Add portal with 3 tiles for text, document, and voice translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Website: https://azure.microsoft.com/en-us/products/ai-services/ai-translator<br
 <br><br>
 > Note: you need to update the **azure.env** file with your Azure AI services informations.
 
-## 2. Some webapp screenshots
+## 2. Azure AI Translator Portal
+Access the main portal to navigate to different functionalities:
+<a href="portal.ipynb">Azure AI Translator Portal</a>
+
+## 3. Some webapp screenshots
 
 ### An exemple of a custom webapp for text translation
 <br>
@@ -44,7 +48,7 @@ Website: https://azure.microsoft.com/en-us/products/ai-services/ai-translator<br
 <br>
 <img src="webapp4.jpg">
 
-## 3. Azure AI features
+## 4. Azure AI features
 
 ### Text Translation
 Execute text translation between supported source and target languages in real time. Create a dynamic dictionary and learn how to prevent translations using the Translator API.
@@ -66,7 +70,7 @@ Build customized models to translate domain- and industry-specific language, ter
 <br><br>
 https://learn.microsoft.com/en-us/azure/ai-services/translator/custom-translator/overview
 
-## 4. Documentation and links
+## 5. Documentation and links
 
 ### Azure AI Translator documentation
 https://learn.microsoft.com/en-us/azure/ai-services/translator/

--- a/portal.ipynb
+++ b/portal.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "# Azure AI Translator Portal\n",
+    "Welcome to the Azure AI Translator Portal. Choose one of the options below to get started."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display, HTML"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create buttons for each functionality\n",
+    "text_translation_button = widgets.Button(description=\"Text Translation\", button_style='info')\n",
+    "document_translation_button = widgets.Button(description=\"Document Translation\", button_style='info')\n",
+    "voice_translation_button = widgets.Button(description=\"Voice Translation\", button_style='info')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define button click event handlers\n",
+    "def on_text_translation_button_clicked(b):\n",
+    "    display(HTML('<a href=\"4 Translation.ipynb\" target=\"_blank\">Go to Text Translation</a>'))\n",
+    "\n",
+    "def on_document_translation_button_clicked(b):\n",
+    "    display(HTML('<a href=\"5 Document translation batch.ipynb\" target=\"_blank\">Go to Document Translation</a>'))\n",
+    "\n",
+    "def on_voice_translation_button_clicked(b):\n",
+    "    display(HTML('<a href=\"7 Vocal Translator using Azure AI.ipynb\" target=\"_blank\">Go to Voice Translation</a>'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assign event handlers to buttons\n",
+    "text_translation_button.on_click(on_text_translation_button_clicked)\n",
+    "document_translation_button.on_click(on_document_translation_button_clicked)\n",
+    "voice_translation_button.on_click(on_voice_translation_button_clicked)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display buttons\n",
+    "display(widgets.HBox([text_translation_button, document_translation_button, voice_translation_button]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.5",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3",
+   "nbconvert_exporter": "python",
+   "file_extension": ".py"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Add a new portal interface to combine text, document, and voice translation functionalities into a single app.

* **portal.ipynb**: Create a new notebook with a portal interface containing three tiles for text translation, document translation, and voice translation. Link each tile to the respective notebooks: `4 Translation.ipynb`, `5 Document translation batch.ipynb`, and `7 Vocal Translator using Azure AI.ipynb`.
* **README.md**: Update instructions to include accessing and using the new portal. Add a section for the Azure AI Translator Portal with a link to `portal.ipynb`. Adjust section numbering accordingly.

